### PR TITLE
Switch SLM classifier to Claude 3.5 Sonnet

### DIFF
--- a/services/slm-classifier/src/index.ts
+++ b/services/slm-classifier/src/index.ts
@@ -129,7 +129,7 @@ ${contextStr || 'EMPTY - No previous context'}
 {"intent": "NEW_TASK" | "FOLLOW_UP" | "REVOKE" | "GENERAL_QUESTION", "confidence": 0.0 to 1.0, "reasoning": "brief explanation"}`;
 
     const response = await openrouter.chat.completions.create({
-      model: 'google/gemini-2.0-flash-001',
+      model: 'anthropic/claude-3.5-sonnet',
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: latest_message },


### PR DESCRIPTION
Use anthropic/claude-3.5-sonnet for message classification instead of google/gemini-2.0-flash-001.

Claude provides better reasoning and accuracy for intent classification (FOLLOW_UP/NEW_TASK detection). Temperature remains at 0.2 for consistent, deterministic results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model used in the classification service while maintaining backward compatibility with existing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->