### PR TITLE
Fix follow-up detection: include bot responses in SLM classifier context

### DIFF
--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -645,10 +645,19 @@ async function getRecentMessages(phoneNumber: string, limit: number = 20, exclud
       taskStartTime = connection.currentTaskStartedAt.getTime();
       console.log(`Using active task context for ${phoneNumber} (started at ${connection.currentTaskStartedAt.toISOString()})`);
     } else if (connection) {
-      // No active task, but check recent messages from last 5 minutes to preserve context for follow-ups
-      // This allows: Q1 -> Answer -> Q2 (follow-up to Q1) pattern
-      taskStartTime = Date.now() - (5 * 60 * 1000);
-      console.log(`No active task for ${phoneNumber}, using recent 5-minute context window for follow-up detection`);
+      // No active task - use the later of: last task start time or 10-minute window.
+      // currentTaskStartedAt persists after task completion, so we can use it to
+      // capture the full conversation from the last task (even if it took >5min).
+      const tenMinutesAgo = Date.now() - (10 * 60 * 1000);
+      const lastTaskStart = (connection as any).currentTaskStartedAt?.getTime();
+      
+      if (lastTaskStart && lastTaskStart > tenMinutesAgo) {
+        taskStartTime = lastTaskStart;
+        console.log(`No active task for ${phoneNumber}, using last task start time ${new Date(lastTaskStart).toISOString()} for follow-up detection`);
+      } else {
+        taskStartTime = tenMinutesAgo;
+        console.log(`No active task for ${phoneNumber}, using 10-minute context window for follow-up detection`);
+      }
     } else {
       console.log(`No active connection for ${phoneNumber}, returning empty context`);
       return [];
@@ -698,9 +707,12 @@ async function getRecentMessages(phoneNumber: string, limit: number = 20, exclud
 
     // Filter messages:
     // 1. Only messages in recent window (active task start or last 5 minutes)
-    // 2. Exclude MANUAL messages
-    // 3. Keep user messages and webhook responses
+    // 2. Exclude MANUAL messages (sent via MCP tool, not part of conversation)
+    // 3. Keep BOTH user messages AND bot responses for full conversation context
+    // 4. Exclude tapbacks/reactions (noise like "Liked ...", "Loved ...")
     const bufferMs = 5000; // 5 second buffer to account for timing differences
+    
+    const tapbackPattern = /^(Liked|Loved|Disliked|Laughed at|Emphasized|Questioned) "/;
     
     console.log(`⏰ Context window start: ${new Date(taskStartTime).toISOString()} (${taskStartTime})`);
     
@@ -709,11 +721,11 @@ async function getRecentMessages(phoneNumber: string, limit: number = 20, exclud
       const passesTimeFilter = messageTime >= (taskStartTime - bufferMs);
       const notManual = !guidSet.has(msg.guid);
       const notCurrent = msg.guid !== excludeMessageGuid;
-      const isRelevantMessage = !msg.isFromMe; // Only include user messages, exclude system/bot messages
+      const isTapback = tapbackPattern.test(msg.text || '');
       
-      console.log(`  Message ${msg.guid?.substring(0, 8)}: time=${passesTimeFilter}, notManual=${notManual}, notCurrent=${notCurrent}, isFromMe=${msg.isFromMe}`);
+      console.log(`  Message ${msg.guid?.substring(0, 8)}: time=${passesTimeFilter}, notManual=${notManual}, notCurrent=${notCurrent}, isFromMe=${msg.isFromMe}, isTapback=${isTapback}`);
       
-      return passesTimeFilter && notManual && notCurrent && isRelevantMessage;
+      return passesTimeFilter && notManual && notCurrent && !isTapback;
     });
 
     console.log(`Fetched ${messages.length} total messages, ${filteredRawMessages.length} after filtering for current task context`);


### PR DESCRIPTION
## Summary

- **Bug**: Follow-up messages like "their emails" (after "give me a list of consulting club presidents at cornell") were being classified as `NEW_TASK` instead of `FOLLOW_UP`, causing a brand new Manus task to be created with no context
- **Root cause**: `getRecentMessages()` filtered out all `isFromMe=true` messages (bot responses) via `const isRelevantMessage = !msg.isFromMe`, so the SLM classifier received **zero context messages** and couldn't detect the follow-up relationship
- **Fix**: Remove the `!isFromMe` filter and replace it with a targeted tapback filter (`Liked "..."`, `Loved "..."`, etc.) so bot responses are included in classifier context. Also widen the fallback time window from 5min to 10min and prefer using `currentTaskStartedAt` when available to capture full task conversations

## What changed

**`services/worker/src/index.ts` — `getRecentMessages()`**:

1. **Message filter** (primary fix): Replaced `!msg.isFromMe` with `!isTapback` — now includes bot responses in SLM context while filtering out reaction noise
2. **Time window** (secondary fix): Fallback window widened from 5min to 10min, and uses `currentTaskStartedAt` (persists after task completion) when available to capture full conversation history from the last task

## Test plan

- [ ] Send a multi-part query: first "give me a list of X" then follow up with "their emails" — should append to existing task, not create new one
- [ ] Verify tapbacks (Liked, Loved, etc.) are still excluded from SLM context
- [ ] Verify MANUAL messages are still excluded
- [ ] Verify completely new topics still get classified as NEW_TASK
- [ ] Check logs to confirm filtered messages now include both user and bot messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Enhancements**
  * Improved conversation context preservation with dynamic message retrieval windows anchored to task timing instead of fixed intervals.
  * Enhanced message filtering to exclude reaction messages and expanded context to include both user and bot messages for richer conversation understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->