### PR TITLE
Prune dev dependencies from production Docker images

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -15,11 +15,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@prisma/client": "^5.8.1"
+    "@prisma/client": "^5.8.1",
+    "prisma": "^5.8.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",
-    "prisma": "^5.8.1",
     "typescript": "^5.3.3"
   }
 }

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -26,6 +26,10 @@ WORKDIR /app
 # Copy everything from build
 COPY --from=build /app ./
 
+# Remove dev dependencies and build artifacts from production image
+RUN pnpm prune --prod --no-optional && \
+    rm -rf /app/.pnpm-store /app/**/src /app/**/*.ts /app/**/tsconfig.json 2>/dev/null || true
+
 # Copy entrypoint script and deploy ops
 COPY services/backend/docker-entrypoint.sh /app/services/backend/
 COPY services/backend/deploy-ops.json /app/services/backend/

--- a/services/slm-classifier/Dockerfile
+++ b/services/slm-classifier/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR /app
 # Copy everything from build
 COPY --from=build /app ./
 
+# Remove dev dependencies and build artifacts from production image
+RUN pnpm prune --prod --no-optional && \
+    rm -rf /app/.pnpm-store /app/**/src /app/**/*.ts /app/**/tsconfig.json 2>/dev/null || true
+
 # Set working directory to service
 WORKDIR /app/services/slm-classifier
 

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -25,6 +25,10 @@ WORKDIR /app
 # Copy everything from build
 COPY --from=build /app ./
 
+# Remove dev dependencies and build artifacts from production image
+RUN pnpm prune --prod --no-optional && \
+    rm -rf /app/.pnpm-store /app/**/src /app/**/*.ts /app/**/tsconfig.json 2>/dev/null || true
+
 # Copy entrypoint script
 COPY services/worker/docker-entrypoint.sh /app/services/worker/
 RUN chmod +x /app/services/worker/docker-entrypoint.sh


### PR DESCRIPTION
Closes #14. Adds pnpm prune --prod to all Dockerfiles and moves prisma to runtime deps.