### PR TITLE
Reduce DB polling from 10s to 60s safety net

### DIFF
--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1599,5 +1599,5 @@ initializeExistingQueues();
 // Listen for instant activation and message notifications
 listenForEvents();
 
-// Check for new connections every 10 seconds (backup mechanism)
-setInterval(checkForNewConnections, 10000);
+// Safety-net poll for new connections every 60s (primary detection is via Redis pub/sub)
+setInterval(checkForNewConnections, 60000);


### PR DESCRIPTION
Closes #16. Primary detection is via Redis pub/sub; polling reduced to 60s backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized connection detection polling to reduce database load while maintaining real-time event-driven activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->