### PR TITLE
Add TTL-based cleanup for unbounded in-memory Maps

### DIFF
--- a/services/backend/src/routes/imessage-webhook.ts
+++ b/services/backend/src/routes/imessage-webhook.ts
@@ -28,7 +28,7 @@ const ONBOARDING_MESSAGES = [
   "Just text me what you need!",
 ];
 
-// Map to cache queues per phone number
+// Per-handle queues -- bounded by number of active connections
 const queues = new Map<string, Queue>();
 
 // Get or create queue for a handle (phone number or email)

--- a/services/backend/src/routes/webhooks.ts
+++ b/services/backend/src/routes/webhooks.ts
@@ -33,7 +33,7 @@ const taskStartTimes = new Map<string, number>();
 const processedWebhooks = new Map<string, number>();
 const WEBHOOK_EXPIRY_MS = 600000; // 10 minutes
 
-// Clean up expired webhook IDs every 5 minutes
+// Clean up stale in-memory entries every 5 minutes
 setInterval(() => {
   const now = Date.now();
   for (const [eventId, timestamp] of processedWebhooks.entries()) {
@@ -41,7 +41,19 @@ setInterval(() => {
       processedWebhooks.delete(eventId);
     }
   }
-}, 300000); // 5 minutes
+  // progressTimestamps entries older than 1 hour are stale (tasks finished long ago)
+  for (const [key, timestamp] of progressTimestamps.entries()) {
+    if (now - timestamp > 3600000) {
+      progressTimestamps.delete(key);
+    }
+  }
+  // taskStartTimes entries older than 1 hour are stale
+  for (const [taskId, timestamp] of taskStartTimes.entries()) {
+    if (now - timestamp > 3600000) {
+      taskStartTimes.delete(taskId);
+    }
+  }
+}, 300000);
 
 export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
   // POST /api/webhooks/manus - Receive webhooks from Manus

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -66,13 +66,10 @@ const redis = new Redis(REDIS_URL, {
   maxRetriesPerRequest: null,
 });
 
-// Map to track queues and workers per phone number
+// Per-handle queues/workers -- bounded by number of active connections (cleaned up on revoke)
 const queues = new Map<string, Queue>();
 const workers = new Map<string, Worker>();
 const debounceTimers = new Map<string, NodeJS.Timeout>();
-
-// Map to track active typing indicators per phone number
-const typingIndicators = new Map<string, NodeJS.Timeout>();
 
 console.log('Worker service starting...');
 


### PR DESCRIPTION
Closes #20. Adds 1-hour TTL cleanup for progressTimestamps and taskStartTimes. Removes dead typingIndicators Map.