### PR TITLE
Re-enable MCP routes that connect flows depend on

### DIFF
--- a/services/backend/src/index.ts
+++ b/services/backend/src/index.ts
@@ -2,10 +2,9 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
 import { prisma } from '@imessage-mcp/database';
-// MCP routes commented out - not needed for current setup
-// import { mcpRoutes } from './routes/mcp';
-// import { mcpSSERoutes } from './routes/mcp-sse';
-// import { mcpHTTPRoutes } from './routes/mcp-http';
+import { mcpRoutes } from './routes/mcp';
+import { mcpSSERoutes } from './routes/mcp-sse';
+import { mcpHTTPRoutes } from './routes/mcp-http';
 import { webhookRoutes } from './routes/webhooks';
 import { imessageWebhookRoutes } from './routes/imessage-webhook';
 
@@ -72,10 +71,9 @@ const loadConnectRoutes = async () => {
 };
 
 // Register other routes immediately
-// MCP routes commented out - not needed for current setup
-// fastify.register(mcpRoutes, { prefix: '/mcp' });
-// fastify.register(mcpSSERoutes, { prefix: '/mcp' });
-// fastify.register(mcpHTTPRoutes, { prefix: '/mcp/http' });
+fastify.register(mcpHTTPRoutes, { prefix: '/mcp/http' });
+fastify.register(mcpSSERoutes, { prefix: '/mcp' });
+fastify.register(mcpRoutes, { prefix: '/mcp' });
 fastify.register(webhookRoutes, { prefix: '' }); // Root level
 fastify.register(imessageWebhookRoutes, { prefix: '' }); // Root level for health
 


### PR DESCRIPTION
## Summary

- The connect flows (v1, v2, legacy) all send users an MCP JSON config pointing at `{PUBLIC_URL}/mcp/http`, but the MCP route plugins were commented out in `index.ts` -- that URL has been 404ing for every user who tries to set up the Manus MCP connector.
- Re-enables all three MCP transport routes: Streamable HTTP (`/mcp/http`), SSE (`/mcp`), and REST (`/mcp/fetch`, `/mcp/send`).
- The route implementations (`mcp-http.ts`, `mcp-sse.ts`, `mcp.ts`) were already complete and unchanged -- only the registration in `index.ts` was disabled.

## Test plan

- [ ] Deploy and verify `POST /mcp/http` returns a proper MCP response (not 404) with a valid Bearer token
- [ ] Verify `/mcp` SSE endpoint establishes a connection
- [ ] Verify `/mcp/fetch` and `/mcp/send` REST endpoints respond
- [ ] Run through the connect-v2 flow end-to-end: user adds API key -> gets MCP config -> pastes into Manus -> Manus can call fetch/send tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP (Model Context Protocol) endpoints are now enabled in the backend, providing Server-Sent Event streaming and HTTP-based integration options that were previously unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->