### PR TITLE
Fix free tier blocking losing attachments and GUIDs

### DIFF
--- a/packages/database/prisma/migrations/20260410000000_replace_pending_message_with_pending_data/migration.sql
+++ b/packages/database/prisma/migrations/20260410000000_replace_pending_message_with_pending_data/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable: Replace text-only pendingMessage with structured JSON pendingData
+-- Migrates any existing pendingMessage values into the new JSON column
+
+-- Step 1: Add the new column
+ALTER TABLE "connections" ADD COLUMN "pendingData" JSONB;
+
+-- Step 2: Migrate any existing pendingMessage values into pendingData as {messageText: "..."}
+UPDATE "connections"
+SET "pendingData" = jsonb_build_object('messageText', "pendingMessage")
+WHERE "pendingMessage" IS NOT NULL;
+
+-- Step 3: Drop the old column
+ALTER TABLE "connections" DROP COLUMN "pendingMessage";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Connection {
   contactCardShared Boolean @default(false) // Track if contact card has been shared with this user
   hasOnboarded  Boolean   @default(false) // Track if user completed onboarding flow
   tasksUsed     Int       @default(0) // Number of free tier tasks used (max 3 before requiring API key)
-  pendingMessage String?  @db.Text // Message blocked at free tier limit, to be processed after API key added
+  pendingData    Json?    // Full blocked message payload (text, attachments, GUIDs) stored at free tier limit
   status        Status    @default(PENDING)
   createdAt     DateTime  @default(now())
   expiresAt     DateTime?

--- a/services/backend/deploy-ops.json
+++ b/services/backend/deploy-ops.json
@@ -2,12 +2,12 @@
   {
     "id": "reset-tasks-3322593374-2026-02-24",
     "description": "Reset tasksUsed for +13322593374 so they can test again",
-    "sql": "UPDATE connections SET \"tasksUsed\" = 0, \"currentTaskId\" = NULL, \"currentTaskStartedAt\" = NULL, \"triggeringMessageGuid\" = NULL, \"pendingMessage\" = NULL WHERE \"phoneNumber\" = '+13322593374';"
+    "sql": "UPDATE connections SET \"tasksUsed\" = 0, \"currentTaskId\" = NULL, \"currentTaskStartedAt\" = NULL, \"triggeringMessageGuid\" = NULL, \"pendingData\" = NULL WHERE \"phoneNumber\" = '+13322593374';"
   },
   {
     "id": "reset-tasks-918527438574-2026-02-24",
     "description": "Reset tasksUsed for +918527438574 so they can test again",
-    "sql": "UPDATE connections SET \"tasksUsed\" = 0, \"currentTaskId\" = NULL, \"currentTaskStartedAt\" = NULL, \"triggeringMessageGuid\" = NULL, \"pendingMessage\" = NULL WHERE \"phoneNumber\" = '+918527438574';"
+    "sql": "UPDATE connections SET \"tasksUsed\" = 0, \"currentTaskId\" = NULL, \"currentTaskStartedAt\" = NULL, \"triggeringMessageGuid\" = NULL, \"pendingData\" = NULL WHERE \"phoneNumber\" = '+918527438574';"
   },
   {
     "id": "add-has-onboarded-column-2026-02-24",

--- a/services/backend/src/routes/imessage-webhook.ts
+++ b/services/backend/src/routes/imessage-webhook.ts
@@ -549,7 +549,7 @@ export async function startIMessageListener() {
                 currentTaskId: null,
                 currentTaskStartedAt: null,
                 triggeringMessageGuid: null,
-                pendingMessage: null,
+                pendingData: null,
                 hasOnboarded: false, // Reset so they get onboarding on re-connect
               } as any,
             });

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -427,7 +427,7 @@ async function processMessage(phoneNumber: string, data: any) {
         await appendToTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageGuid);
       } else {
         console.log(`📎 File-only message with no active task - creating new task`);
-        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, false, effectiveMessageGuid);
+        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, false, effectiveMessageGuid, false, effectiveThreadOriginatorGuid);
       }
     } else {
       const { isFollowUp, taskId: taskIdForThread, intent, reasoning } = await detectMessageType(
@@ -478,7 +478,7 @@ async function processMessage(phoneNumber: string, data: any) {
           console.log(`✅ Cleared previous task ID for ${phoneNumber} (NEW_TASK)`);
         }
         
-        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, true, effectiveMessageGuid);
+        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, true, effectiveMessageGuid, false, effectiveThreadOriginatorGuid);
       }
     }
 
@@ -827,7 +827,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: { phoneNumber },
-        data: { tasksUsed: 0, pendingData: null } as any,
+        data: { tasksUsed: 0 } as any,
       });
       if (result.count > 0) {
         await sendMessage('✅ Your tasks have been reset to 0.');
@@ -849,7 +849,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: { phoneNumber: targetPhone },
-        data: { tasksUsed: 0, pendingData: null } as any,
+        data: { tasksUsed: 0 } as any,
       });
       if (result.count > 0) {
         await sendMessage(`✅ Tasks reset for ${targetPhone}`);
@@ -869,7 +869,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: {},
-        data: { tasksUsed: 0, pendingData: null } as any,
+        data: { tasksUsed: 0 } as any,
       });
       await sendMessage(`✅ Tasks reset for ${result.count} user(s).`);
       return true;
@@ -1086,7 +1086,8 @@ async function createManusTask(
   messageTimestamp?: Date | string,
   preserveTaskStartTime: boolean = false,
   triggeringMessageGuid?: string,
-  isFollowUp: boolean = false
+  isFollowUp: boolean = false,
+  threadOriginatorGuid?: string,
 ) {
   console.log(`Creating new Manus task for ${phoneNumber}:`, message, fileIds.length > 0 ? `with ${fileIds.length} file(s)` : '');
   
@@ -1106,7 +1107,7 @@ async function createManusTask(
     await sendFreeTierLimitPrompt(phoneNumber, {
       messageText: message,
       messageGuid: triggeringMessageGuid || null,
-      threadOriginatorGuid: null,
+      threadOriginatorGuid: threadOriginatorGuid || null,
       attachments: null,
       messageTimestamp: messageTimestamp || null,
     });

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -246,37 +246,56 @@ async function processMessage(phoneNumber: string, data: any) {
   const { messageId, messageText, attachments, messageGuid, threadOriginatorGuid, messageTimestamp } = data;
 
   try {
-    // Check for pending message (message that was blocked due to free tier limit)
-    // and combine it with the current message after user has added their API key
     let combinedMessage = messageText;
+    let pendingAttachments: Array<{ guid: string; filename: string; mimeType: string }> | null = null;
+    let pendingMessageGuid: string | null = null;
+    let pendingThreadOriginatorGuid: string | null = null;
+    let pendingMessageTimestamp: string | null = null;
+
     const connection = await prisma.connection.findFirst({
       where: { phoneNumber, status: 'ACTIVE' },
     });
     
-    const pendingMessage = (connection as any)?.pendingMessage;
-    if (pendingMessage && connection?.manusApiKey) {
-      console.log(`📋 Found pending message for ${phoneNumber}, combining with current message`);
+    const pendingData = (connection as any)?.pendingData as {
+      messageText?: string | null;
+      messageGuid?: string | null;
+      threadOriginatorGuid?: string | null;
+      attachments?: Array<{ guid: string; filename: string; mimeType: string }> | null;
+      messageTimestamp?: string | null;
+    } | null;
+
+    const tasksAvailable = connection?.manusApiKey || ((connection?.tasksUsed ?? 0) < FREE_TIER_TASKS);
+
+    if (pendingData && tasksAvailable) {
+      console.log(`📋 Found pending data for ${phoneNumber}, replaying blocked message`);
       
-      // If user sends "continue" (case insensitive), just use the pending message
-      // Otherwise, combine both messages
       const isContinue = /^continue$/i.test(messageText?.trim() || '');
       if (isContinue) {
-        combinedMessage = pendingMessage;
+        combinedMessage = pendingData.messageText || '';
         console.log(`📋 User said "continue" - using pending message only`);
       } else if (messageText) {
-        combinedMessage = `${pendingMessage}\n\n${messageText}`;
+        combinedMessage = pendingData.messageText
+          ? `${pendingData.messageText}\n\n${messageText}`
+          : messageText;
         console.log(`📋 Combining pending message with new message`);
       } else {
-        combinedMessage = pendingMessage;
+        combinedMessage = pendingData.messageText || '';
         console.log(`📋 No new message text - using pending message only`);
       }
+
+      pendingAttachments = pendingData.attachments || null;
+      pendingMessageGuid = pendingData.messageGuid || null;
+      pendingThreadOriginatorGuid = pendingData.threadOriginatorGuid || null;
+      pendingMessageTimestamp = pendingData.messageTimestamp || null;
       
-      // Clear the pending message
       await prisma.connection.update({
-        where: { id: connection.id },
-        data: { pendingMessage: null } as any,
+        where: { id: connection!.id },
+        data: { pendingData: null } as any,
       });
-      console.log(`✅ Cleared pending message for ${phoneNumber}`);
+      console.log(`✅ Cleared pending data for ${phoneNumber}`, {
+        hadText: !!pendingData.messageText,
+        hadAttachments: (pendingData.attachments || []).length,
+      });
     }
     
     // Check for admin commands FIRST (before free tier check)
@@ -305,12 +324,10 @@ async function processMessage(phoneNumber: string, data: any) {
     if (connForFreeTierCheck) {
       const { needsApiKeyPrompt } = await resolveApiKeyForConnection(connForFreeTierCheck);
       if (needsApiKeyPrompt) {
-        const existingPendingMessage = (connForFreeTierCheck as any)?.pendingMessage;
+        const existingPendingData = (connForFreeTierCheck as any)?.pendingData;
         
-        if (existingPendingMessage) {
-          // User already has a pending message and still hasn't added API key
-          // Don't overwrite the original blocked message, just remind them to add key
-          console.log('📊 Free tier exhausted - user has existing pending message, sending reminder');
+        if (existingPendingData) {
+          console.log('📊 Free tier exhausted - user has existing pending data, sending reminder');
           
           const sdk = await getIMessageSDK();
           const chatGuid = `any;-;${phoneNumber}`;
@@ -322,16 +339,15 @@ async function processMessage(phoneNumber: string, data: any) {
             message: "Please add your API key first to continue. Get it here:\nhttps://manus.im/app#settings/integrations/api",
           });
         } else {
-          // First time hitting limit - store message and send full prompt
-          console.log('📊 Free tier exhausted - sending prompt before attachment processing');
-          // Build message to store (include attachment mention if relevant)
-          let blockedMsg = combinedMessage || '';
-          if (attachments && attachments.length > 0) {
-            blockedMsg = blockedMsg 
-              ? `${blockedMsg}\n\n[User also sent ${attachments.length} file(s) that need to be re-sent after adding API key]`
-              : `[User sent ${attachments.length} file(s) - please re-send after adding API key]`;
-          }
-          await sendFreeTierLimitPrompt(phoneNumber, blockedMsg);
+          console.log('📊 Free tier exhausted - storing full pending data before attachment processing');
+          const blockedData = {
+            messageText: combinedMessage || null,
+            messageGuid,
+            threadOriginatorGuid: threadOriginatorGuid || null,
+            attachments: (attachments && attachments.length > 0) ? attachments : null,
+            messageTimestamp: messageTimestamp || null,
+          };
+          await sendFreeTierLimitPrompt(phoneNumber, blockedData);
         }
         
         // Mark message as completed (not failed - we handled it)
@@ -346,36 +362,42 @@ async function processMessage(phoneNumber: string, data: any) {
       }
     }
     
-    // Handle attachments if present
+    // Handle attachments: current message attachments + any replayed pending attachments
     let fileIds: string[] = [];
     if (attachments && attachments.length > 0) {
       fileIds = await processAttachments(phoneNumber, attachments);
     }
+    if (pendingAttachments && pendingAttachments.length > 0) {
+      console.log(`📎 Processing ${pendingAttachments.length} replayed pending attachment(s)`);
+      const pendingFileIds = await processAttachments(phoneNumber, pendingAttachments);
+      fileIds = [...fileIds, ...pendingFileIds];
+    }
 
-    // If message is empty but has attachments, use a default prompt
     let effectiveMessage = combinedMessage;
     if (!effectiveMessage && fileIds.length > 0) {
       effectiveMessage = `[User sent ${fileIds.length} file(s)]`;
     }
 
-    // Skip processing if both message and attachments are empty
     if (!effectiveMessage && fileIds.length === 0) {
       console.warn(`Skipping empty message for ${phoneNumber}`);
       return;
     }
 
-    // Resolve thread reply before any branching so file-only replies also route correctly
+    // Use pending GUIDs as fallback when replaying a blocked message
+    const effectiveThreadOriginatorGuid = threadOriginatorGuid || pendingThreadOriginatorGuid;
+    const effectiveMessageGuid = messageGuid || pendingMessageGuid;
+    const effectiveMessageTimestamp = messageTimestamp || pendingMessageTimestamp;
+
     let threadTaskId: string | null = null;
-    if (threadOriginatorGuid) {
-      const msgTaskKey = `msg:task:${threadOriginatorGuid}`;
+    if (effectiveThreadOriginatorGuid) {
+      const msgTaskKey = `msg:task:${effectiveThreadOriginatorGuid}`;
       threadTaskId = await redis.get(msgTaskKey);
       if (threadTaskId) {
-        console.log(`🧵 Thread reply detected: ${threadOriginatorGuid} → task ${threadTaskId}`);
+        console.log(`🧵 Thread reply detected: ${effectiveThreadOriginatorGuid} → task ${threadTaskId}`);
       }
     }
 
     if (threadTaskId) {
-      // Thread reply to a known task → append directly, skip SLM
       const connForThread = await prisma.connection.findFirst({
         where: { phoneNumber, status: 'ACTIVE' },
       });
@@ -390,40 +412,36 @@ async function processMessage(phoneNumber: string, data: any) {
         where: { phoneNumber },
         data: { 
           currentTaskId: threadTaskId,
-          triggeringMessageGuid: messageGuid,
+          triggeringMessageGuid: effectiveMessageGuid,
         },
       });
       
-      await appendToTask(phoneNumber, effectiveMessage, fileIds, messageGuid, true);
+      await appendToTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageGuid, true);
     } else if (!combinedMessage && fileIds.length > 0) {
-      // File-only message (no text, no pending message, no thread context)
       const connForFiles = await prisma.connection.findFirst({
         where: { phoneNumber, status: 'ACTIVE' },
       });
 
       if (connForFiles?.currentTaskId) {
         console.log(`📎 File-only message with active task - appending to ${connForFiles.currentTaskId}`);
-        await appendToTask(phoneNumber, effectiveMessage, fileIds, messageGuid);
+        await appendToTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageGuid);
       } else {
         console.log(`📎 File-only message with no active task - creating new task`);
-        await createManusTask(phoneNumber, effectiveMessage, fileIds, messageTimestamp, false, messageGuid);
+        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, false, effectiveMessageGuid);
       }
     } else {
-      // Regular message — use SLM agentic routing
       const { isFollowUp, taskId: taskIdForThread, intent, reasoning } = await detectMessageType(
         phoneNumber,
         messageText || '',
-        messageGuid
+        effectiveMessageGuid
       );
 
-      // Re-fetch connection for task handling
       const connForTask = await prisma.connection.findFirst({
         where: { phoneNumber, status: 'ACTIVE' },
       });
 
-      // Check if this is a pre-defined intent that should be handled without Manus
       if (intent) {
-        const handled = await handlePredefinedIntent(phoneNumber, intent, connForTask, messageGuid, messageText);
+        const handled = await handlePredefinedIntent(phoneNumber, intent, connForTask, effectiveMessageGuid, messageText);
         if (handled) {
           console.log(`✅ Pre-defined intent ${intent} handled for ${phoneNumber}${reasoning ? ` (${reasoning})` : ''}`);
           await prisma.messageQueue.update({
@@ -438,20 +456,18 @@ async function processMessage(phoneNumber: string, data: any) {
       }
 
       if (isFollowUp && taskIdForThread) {
-        // Follow-up detected → append to existing task
         console.log(`✅ Follow-up detected - appending to task ${taskIdForThread}${reasoning ? ` (${reasoning})` : ''}`);
         
         await prisma.connection.update({
           where: { phoneNumber },
           data: { 
             currentTaskId: taskIdForThread,
-            triggeringMessageGuid: messageGuid,
+            triggeringMessageGuid: effectiveMessageGuid,
           },
         });
         
-        await appendToTask(phoneNumber, effectiveMessage, fileIds, messageGuid, true);
+        await appendToTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageGuid, true);
       } else {
-        // New task → clear previous task and create new one
         console.log(`🆕 New task detected for ${phoneNumber}${reasoning ? ` (${reasoning})` : ''}`);
         
         if (connForTask?.currentTaskId) {
@@ -462,8 +478,7 @@ async function processMessage(phoneNumber: string, data: any) {
           console.log(`✅ Cleared previous task ID for ${phoneNumber} (NEW_TASK)`);
         }
         
-        // Preserve conversation history across task boundaries
-        await createManusTask(phoneNumber, effectiveMessage, fileIds, messageTimestamp, true, messageGuid);
+        await createManusTask(phoneNumber, effectiveMessage, fileIds, effectiveMessageTimestamp, true, effectiveMessageGuid);
       }
     }
 
@@ -812,7 +827,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: { phoneNumber },
-        data: { tasksUsed: 0 } as any,
+        data: { tasksUsed: 0, pendingData: null } as any,
       });
       if (result.count > 0) {
         await sendMessage('✅ Your tasks have been reset to 0.');
@@ -834,7 +849,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: { phoneNumber: targetPhone },
-        data: { tasksUsed: 0 } as any,
+        data: { tasksUsed: 0, pendingData: null } as any,
       });
       if (result.count > 0) {
         await sendMessage(`✅ Tasks reset for ${targetPhone}`);
@@ -854,7 +869,7 @@ async function handleAdminCommand(
     try {
       const result = await prisma.connection.updateMany({
         where: {},
-        data: { tasksUsed: 0 } as any,
+        data: { tasksUsed: 0, pendingData: null } as any,
       });
       await sendMessage(`✅ Tasks reset for ${result.count} user(s).`);
       return true;
@@ -1000,22 +1015,21 @@ async function resolveApiKeyForConnection(connection: any): Promise<{
 
 /**
  * Send multi-message prompt when user hits free tier limit
- * Only stores and sends if no pending message exists (to avoid overwriting)
+ * Stores the full message payload (text + attachments + GUIDs) so it can be replayed later.
  */
-async function sendFreeTierLimitPrompt(phoneNumber: string, blockedMessage: string): Promise<void> {
+async function sendFreeTierLimitPrompt(phoneNumber: string, pendingData: Record<string, unknown>): Promise<void> {
   console.log(`📢 Sending free tier limit prompt to ${phoneNumber}`);
   
   try {
     const sdk = await getIMessageSDK();
     const chatGuid = `any;-;${phoneNumber}`;
     
-    // Check if there's already a pending message (don't overwrite)
     const existingConn = await prisma.connection.findFirst({
       where: { phoneNumber, status: 'ACTIVE' },
     });
     
-    if ((existingConn as any)?.pendingMessage) {
-      console.log(`⚠️ User already has pending message, not overwriting. Sending reminder instead.`);
+    if ((existingConn as any)?.pendingData) {
+      console.log(`⚠️ User already has pending data, not overwriting. Sending reminder instead.`);
       await sdk.chats.startTyping(chatGuid);
       await new Promise(resolve => setTimeout(resolve, 1000));
       await sdk.chats.stopTyping(chatGuid);
@@ -1026,12 +1040,14 @@ async function sendFreeTierLimitPrompt(phoneNumber: string, blockedMessage: stri
       return;
     }
     
-    // Store the blocked message as pendingMessage
     await prisma.connection.updateMany({
       where: { phoneNumber, status: 'ACTIVE' },
-      data: { pendingMessage: blockedMessage } as any,
+      data: { pendingData } as any,
     });
-    console.log(`✅ Stored pending message for ${phoneNumber}`);
+    console.log(`✅ Stored pending data for ${phoneNumber}:`, { 
+      hasText: !!(pendingData as any).messageText,
+      attachments: ((pendingData as any).attachments || []).length,
+    });
     
     // Send multi-message prompt with typing indicators
     const messages = [
@@ -1084,13 +1100,17 @@ async function createManusTask(
     throw new Error('No active connection found');
   }
 
-  // Resolve API key (user's own key vs free tier system key)
   const { apiKey, shouldIncrementTasksUsed, needsApiKeyPrompt } = await resolveApiKeyForConnection(connection);
   
   if (needsApiKeyPrompt) {
-    // User has exhausted free tier, send prompt and store message for later
-    await sendFreeTierLimitPrompt(phoneNumber, message);
-    return; // Don't create task
+    await sendFreeTierLimitPrompt(phoneNumber, {
+      messageText: message,
+      messageGuid: triggeringMessageGuid || null,
+      threadOriginatorGuid: null,
+      attachments: null,
+      messageTimestamp: messageTimestamp || null,
+    });
+    return;
   }
   
   if (!apiKey) {
@@ -1251,13 +1271,17 @@ async function appendToTask(phoneNumber: string, message: string, fileIds: strin
     throw new Error('No active connection found');
   }
 
-  // Resolve API key (user's own key vs free tier system key)
   const { apiKey, shouldIncrementTasksUsed, needsApiKeyPrompt } = await resolveApiKeyForConnection(connection);
   
   if (needsApiKeyPrompt) {
-    // User has exhausted free tier, send prompt and store message for later
-    await sendFreeTierLimitPrompt(phoneNumber, message);
-    return; // Don't append to task
+    await sendFreeTierLimitPrompt(phoneNumber, {
+      messageText: message,
+      messageGuid: triggeringMessageGuid || null,
+      threadOriginatorGuid: null,
+      attachments: null,
+      messageTimestamp: null,
+    });
+    return;
   }
   
   if (!apiKey) {


### PR DESCRIPTION
## Summary

- When the free tier blocks a message with attachments, the attachment GUIDs were lost — only text was stored with a `[User sent N file(s)]` placeholder. Thread replies to blocked messages also failed silently because no `msg:task:*` Redis mapping existed for the original message GUID.
- The replay logic only triggered when `manusApiKey` was set, so `admin reset` (which only resets `tasksUsed`) never replayed pending data.
- Replaces text-only `pendingMessage String?` with structured `pendingData Json?` that stores the full payload: `{ messageText, messageGuid, threadOriginatorGuid, attachments, messageTimestamp }`.

## What changed

| File | Change |
|------|--------|
| `schema.prisma` | `pendingMessage String?` → `pendingData Json?` |
| Migration SQL | Add column, migrate existing text values, drop old column |
| `worker/index.ts` | Store full payload on block; replay attachments + GUIDs on resume; use effective GUIDs in routing; clear `pendingData` on admin reset |
| `imessage-webhook.ts` | Revoke flow clears `pendingData` |
| `deploy-ops.json` | Update historical SQL templates |

## Test plan

- [ ] Send a message with an image while free tier is exhausted → verify `pendingData` stores attachment GUIDs
- [ ] Admin `reset` → send "continue" → verify attachment is uploaded and task created with the image
- [ ] Thread-reply to a previously blocked message after reset → verify it routes correctly
- [ ] Add API key after exhaustion → send "continue" → verify replay includes attachments
- [ ] Revoke and reconnect → verify `pendingData` is cleared
- [ ] Run `prisma migrate deploy` → verify migration applies cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced single-text pending storage with structured pending data to preserve message text, attachments, timestamps, and identifiers.
  * Migrated existing pending text into the new structured format.

* **User-facing Improvements**
  * When quota is exceeded, full message context is now preserved for later replay instead of a plain blocked message.
  * Replayed messages merge attachments and use original timestamps/ids for correct routing.

* **Bug Fix**
  * Prevents overwriting existing pending data when one is already stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->