### PR TITLE
Align watchdog disk threshold in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,10 @@ ADMIN_PHONES=
 # Incoming webhook URL for container health/resource alerts
 # Create one at: https://api.slack.com/messaging/webhooks
 SLACK_WEBHOOK_URL=
-# Thresholds (optional — defaults: CPU 80%, Memory 80%, Disk 85%)
+# Thresholds (optional — defaults: CPU 80%, Memory 80%, Disk 90%)
 # CPU_THRESHOLD=80
 # MEM_THRESHOLD=80
-# DISK_THRESHOLD=85
+# DISK_THRESHOLD=90
 
 # OpenPanel Analytics
 # Leave empty to disable OpenPanel tracking

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       CHECK_INTERVAL: ${CHECK_INTERVAL:-60}
       CPU_THRESHOLD: ${CPU_THRESHOLD:-80}
       MEM_THRESHOLD: ${MEM_THRESHOLD:-80}
-      DISK_THRESHOLD: ${DISK_THRESHOLD:-85}
+      DISK_THRESHOLD: ${DISK_THRESHOLD:-90}
       COOLDOWN_SECONDS: ${COOLDOWN_SECONDS:-300}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## Summary\n- update the regular docker-compose watchdog DISK_THRESHOLD default from 85% to 90%\n- update .env.example so documented watchdog defaults match the actual defaults\n\n## Why\nThe active deployment appears to use docker-compose.yml rather than docker-compose.prod.yml. The previous PR updated production compose and the script fallback, but docker-compose.yml still injected DISK_THRESHOLD=85 into the container environment, causing alerts to continue at threshold 85%.\n\n## Validation\n- sh -n scripts/watchdog.sh\n- grep confirmed all watchdog DISK_THRESHOLD defaults are now 90%

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/manus/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783304486&installation_id=127326493&pr_number=51&repository=photon-hq%2Fmanus&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fmanus%2Fpull%2F51&signature=7dc09e2a53bd0e9fafdfde3de5b3a42702379f2029571bba88d6ad69285670a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default disk usage alert threshold from 85% to 90% for watchdog service monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->